### PR TITLE
Fixed deprecation warnings for certain code in PHP 8.4 and later.

### DIFF
--- a/src/Maps/YarnMap.php
+++ b/src/Maps/YarnMap.php
@@ -14,14 +14,14 @@ class YarnMap extends ObfuscationMap
     protected function parseMappings(): void
     {
         foreach (preg_split("/((\r?\n)|(\r\n?))/", $this->content) as $line) {
-            $data = str_getcsv($line, "\t");
+            $data = str_getcsv($line, "\t", enclosure: '"', escape: "");
             $type = $data[0];
 
             $named = array_pop($data);
-            $named = str_replace("/", ".", $named);
+            $named = str_replace("/", ".", $named?? "" );
 
             $intermediary = array_pop($data);
-            $intermediary = str_replace("/", ".", $intermediary);
+            $intermediary = str_replace("/", ".", $intermediary ?? "" );
 
             switch ($type) {
                 case "CLASS":
@@ -37,7 +37,7 @@ class YarnMap extends ObfuscationMap
                     break;
 
                 case "v1":
-                case "";
+                case "":
                 case " ":
                     break;
 

--- a/src/Maps/YarnMap.php
+++ b/src/Maps/YarnMap.php
@@ -18,7 +18,7 @@ class YarnMap extends ObfuscationMap
             $type = $data[0];
 
             $named = array_pop($data);
-            $named = str_replace("/", ".", $named?? "" );
+            $named = str_replace("/", ".", $named ?? "" );
 
             $intermediary = array_pop($data);
             $intermediary = str_replace("/", ".", $intermediary ?? "" );


### PR DESCRIPTION
Fixed deprecation warnings for certain code in PHP 8.4 and later.

> For specific details, see #4 

Why are there two commits? Because I made a rather silly mistake in the first commit.
